### PR TITLE
Use Data Service class instead of db collection direct access

### DIFF
--- a/PopUpZendoTimer/Controller/Groups/GroupsCreateVC.swift
+++ b/PopUpZendoTimer/Controller/Groups/GroupsCreateVC.swift
@@ -174,7 +174,7 @@ class GroupsCreateVC: UIViewController {
     
     
     func getUserName () {
-       let docRef = db.collection("bodhi").document(uid)
+        let docRef = DataService.instance.bodhi_collection.document(uid)
 
        docRef.getDocument { (document, error) in
            if let document = document, document.exists {

--- a/PopUpZendoTimer/Controller/Groups/GroupsEditVC.swift
+++ b/PopUpZendoTimer/Controller/Groups/GroupsEditVC.swift
@@ -59,7 +59,7 @@ class GroupsEditVC: UIViewController {
     }
     
     func getOneGroup () {
-        db.collection("groups").document("Practical Zen")
+        DataService.instance.groups_collection.document("Practical Zen")
         .addSnapshotListener { documentSnapshot, error in
           guard let document = documentSnapshot else {
             print("Error fetching document: \(error!)")

--- a/PopUpZendoTimer/Controller/Groups/TableViewController.swift
+++ b/PopUpZendoTimer/Controller/Groups/TableViewController.swift
@@ -24,7 +24,12 @@ class TableViewController: UITableViewController, UISearchBarDelegate {
         searchBar.delegate = self
         self.sanghaArray = FirebaseInterface.instance.groups ?? []
         self.filteredSanghaArray = self.sanghaArray
-        self.myGroupsArray = self.sanghaArray.filter{ $0.members.contains(uid) }
+
+        // only update myGroupsArray if the uid is not nil
+        if let uid = DataService.instance.uid {
+            self.myGroupsArray = self.sanghaArray.filter{ $0.members.contains(uid) }
+        }
+        
         ///self.myGroupsArray.forEach { print("myGroupsArray====== \($0)") }
         self.tableView.reloadData()
         print(self.sanghaArray.count)

--- a/PopUpZendoTimer/Controller/HomeViewController.swift
+++ b/PopUpZendoTimer/Controller/HomeViewController.swift
@@ -105,7 +105,7 @@ class HomeViewController: UIViewController, CircleMenuDelegate {
         if profileImageURL == "" {
             self.profilePic.image = UIImage(named: "profile-zen")
         } else {
-       let httpsReference = storage.reference(forURL: imageURL)
+        let httpsReference = DataService.instance.storage.reference(forURL: imageURL)
         var profileImage = UIImage(named: "profile-zen")
         httpsReference.getData(maxSize: 10 * 1024 * 1024) { data, error in
           if let error = error {
@@ -121,8 +121,8 @@ class HomeViewController: UIViewController, CircleMenuDelegate {
     }
     
     func readProfile () {
-        guard let uid = uid else { return }
-        db.collection("bodhi").document(uid)
+        guard let uid = DataService.instance.uid else { return }
+        DataService.instance.bodhi_collection.document(uid)
             .addSnapshotListener { documentSnapshot, error in
                 guard let document = documentSnapshot else {
                     print("Error fetching document: \(error!)")

--- a/PopUpZendoTimer/Controller/New Group/GroupsVCTest.swift
+++ b/PopUpZendoTimer/Controller/New Group/GroupsVCTest.swift
@@ -66,7 +66,7 @@ class GroupsVCTest: UIViewController {
 //           }
     
     func getGroups() {
-        db.collection("groups")
+        DataService.instance.groups_collection
                    .addSnapshotListener { querySnapshot, error in
                        guard let documents = querySnapshot?.documents else {
                            print("Error fetching documents: \(error!)")
@@ -87,7 +87,7 @@ class GroupsVCTest: UIViewController {
     }
     
     func getOneGroup () {
-       db.collection("groups").document("Practical Zen")
+       DataService.instance.groups_collection.document("Practical Zen")
        .addSnapshotListener { documentSnapshot, error in
          guard let document = documentSnapshot else {
            print("Error fetching document: \(error!)")
@@ -144,7 +144,7 @@ class GroupsVCTest: UIViewController {
       }
     
   func getUserName () {
-    let docRef = db.collection("bodhi").document(uid)
+    let docRef = DataService.instance.bodhi_collection.document(uid)
 
     docRef.getDocument { (document, error) in
         if let document = document, document.exists {

--- a/PopUpZendoTimer/Controller/ProfileVC.swift
+++ b/PopUpZendoTimer/Controller/ProfileVC.swift
@@ -68,7 +68,7 @@ class ProfileVC: UIViewController {
         // ensure uid is not nil before proceeding to read profile
         guard let uid = uid else { return }
         
-        db.collection("bodhi").document(uid)
+        DataService.instance.bodhi_collection.document(uid)
         .addSnapshotListener { documentSnapshot, error in
           guard let document = documentSnapshot else {
             print("Error fetching document: \(error!)")
@@ -97,7 +97,7 @@ class ProfileVC: UIViewController {
 
     
     func setupView() {
-        let docRef = db.collection("bodhi").document(uid)
+        let docRef = DataService.instance.bodhi_collection.document(uid)
         var profile = ""
         docRef.getDocument { (document, error) in
             if let document = document, document.exists {
@@ -176,7 +176,7 @@ class ProfileVC: UIViewController {
         if profileImageURL == "" {
             self.profileImage.image = UIImage(named: "profile-zen")
         } else {
-       let httpsReference = storage.reference(forURL: imageURL)
+        let httpsReference = DataService.instance.storage.reference(forURL: imageURL)
         var profileImage = UIImage(named: "profile-zen")
         httpsReference.getData(maxSize: 10 * 1024 * 1024) { data, error in
           if let error = error {

--- a/PopUpZendoTimer/View/DemoCell.swift
+++ b/PopUpZendoTimer/View/DemoCell.swift
@@ -61,7 +61,8 @@ class DemoCell: FoldingCell {
         let zoomLink = "https://zoom.us/j/\(zoom))"
         self.websiteURL = website
         self.memberArray = members
-        if memberArray.contains(uid) {
+        if let uid = DataService.instance.uid,
+            memberArray.contains(uid) {
             self.join.setTitle("Member", for: .normal)
             self.join.setBackgroundColor(color: UIColor.white, forState: .normal)
         }
@@ -82,7 +83,7 @@ class DemoCell: FoldingCell {
     
     
     func getBannerImage (imageURL: String) -> UIImage{
-       let httpsReference = storage.reference(forURL: imageURL)
+        let httpsReference = DataService.instance.storage.reference(forURL: imageURL)
         var bannerImage = UIImage(named: "small-bell")
         // Download in memory with a maximum allowed size of 1MB (1 * 1024 * 1024 bytes)
         httpsReference.getData(maxSize: 3 * 1024 * 1024) { data, error in
@@ -100,7 +101,7 @@ class DemoCell: FoldingCell {
     }
     
     func getLogoImage (imageURL: String) -> UIImage{
-       let httpsReference = storage.reference(forURL: imageURL)
+        let httpsReference = DataService.instance.storage.reference(forURL: imageURL)
         var logoImage = UIImage(named: "small-bell")
         // Download in memory with a maximum allowed size of 1MB (1 * 1024 * 1024 bytes)
         httpsReference.getData(maxSize: 3 * 1024 * 1024) { data, error in
@@ -118,6 +119,12 @@ class DemoCell: FoldingCell {
     }
     
     func joinGroup(groupName: String) {
+        // handling nil uid
+        guard let uid = DataService.instance.uid else {
+            print("uid is nil")
+            return
+        }
+        
         DataService.instance.selectGroup(withName: groupName, withSenderID: uid, forUID: uid, withBodhiKey: nil, sendComplete: { (isComplete) in
             if isComplete {
                 //                self.sendBtn.isEnabled = true
@@ -130,6 +137,12 @@ class DemoCell: FoldingCell {
     }
 
     func leaveGroup(groupName: String) {
+        // handling nil uid
+        guard let uid = DataService.instance.uid else {
+            print("uid is nil")
+            return
+        }
+        
        DataService.instance.leaveGroup(withName: groupName, withSenderID: uid, forUID: uid, withBodhiKey: nil, sendComplete: { (isComplete) in
             if isComplete {
                 //                self.sendBtn.isEnabled = true

--- a/Services/OneSignalService.swift
+++ b/Services/OneSignalService.swift
@@ -29,7 +29,7 @@ class OneSignalService {
             bodhi?.save()
             //sendComplete(true)
         } else {
-            db.collection("bodhi").document(uid).updateData([
+            DataService.instance.bodhi_collection.document(uid).updateData([
                 "playerId": playerId,
                 "senderId": uid
             ]) { err in
@@ -44,6 +44,11 @@ class OneSignalService {
     var playerIdList = [""]
     
     func prepareToBroadcast(selectedGroup: String, completion: @escaping ([String]) -> Void) /*-> [String] */ {
+        // return the function early (ie. stop execution) if the uid is nil
+        guard let uid = DataService.instance.uid else {
+            return
+        }
+        
         //        Access the data
         FirebaseInterface.instance.fetchGroups { sanghaArray in
             guard let sangha = sanghaArray.first(where: { $0.groupName.contains(selectedGroup) }) else { return }


### PR DESCRIPTION
Use Data Service class instead of db collection direct access

This should fix some nil error crashes due to nil value of uid in Data Service. Refering to #2 

I suggest to use DataService.instance.bodhi_collection (or other collection name) when you want to read/write to the collection.

@ShinboJosephHall  You can try switch to this branch using SourceTree and test it on your iPhone or Simulator, let me know if the crash issue still occurs when user sign up/ sign in / logout