### PR TITLE
Updated root view controller changing code

### DIFF
--- a/PopUpZendoTimer/Controller/LogInViewController.swift
+++ b/PopUpZendoTimer/Controller/LogInViewController.swift
@@ -80,10 +80,13 @@ class LogInViewController: UIViewController {
                     })
                 }
                 
-                let homeViewController = self.storyboard?.instantiateViewController(withIdentifier: "HomeVC")
-                
-                self.view.window?.rootViewController = homeViewController
-                self.view.window?.makeKeyAndVisible()
+                // set the root view controller to Home VC
+                if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+                    let window = appDelegate.window,
+                    let homeVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: Constants.Storyboard.homeViewController) as? HomeViewController {
+                    
+                    window.rootViewController = homeVC
+                }
             }
         }
     }

--- a/PopUpZendoTimer/Controller/SignUpViewController.swift
+++ b/PopUpZendoTimer/Controller/SignUpViewController.swift
@@ -167,19 +167,12 @@ class SignUpViewController: UIViewController {
         }
         
         func transitionToHome() {
-
-            if #available(iOS 13.0, *) {
-                let homeViewController = storyboard?.instantiateViewController(identifier: Constants.Storyboard.homeViewController) as? HomeViewController
-                view.window?.rootViewController = homeViewController
-                view.window?.makeKeyAndVisible()
-            } else {
-                let storyboard = UIStoryboard(name: "Main", bundle: nil)
-                let homeViewController = storyboard.instantiateViewController(withIdentifier: "HomeVC")
-                view.window?.rootViewController = homeViewController
-                view.window?.makeKeyAndVisible()
-            }
-
-
+            
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+               let window = appDelegate.window,
+               let homeVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: Constants.Storyboard.homeViewController) as? HomeViewController {
+               
+               window.rootViewController = homeVC
+           }
         }
-        
     }


### PR DESCRIPTION
Updated root view controller changing code

Previously the code was using `self.view.window` to access the root view controller. However `self.view.window` can be nil when the current view controller is presented modally (ie. with the card like transition). 

I recommend accessing root view controller using the AppDelegate's window property like this : 
```swift
if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
   let window = appDelegate.window,
   let homeVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: Constants.Storyboard.homeViewController) as? HomeViewController {
               
        window.rootViewController = homeVC
}
```